### PR TITLE
Fix lto build on clang by marking HolderBase::operator() as abstract

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -611,7 +611,7 @@ public:
 
 private:
   struct HolderBase {
-    virtual void operator()() const;
+    virtual void operator()() const = 0;
   };
   template <typename T>
   struct FuncHolder: HolderBase {


### PR DESCRIPTION
Otherwise errors such as 
```
bin/watchman/libwatchman.a(watchman.pic.o):(.data+0x30e48): undefined reference to `typeinfo for subprocess::preexec_func::HolderBase'
bin/watchman/libwatchman.a(watchman.pic.o):(.data+0x31e28): undefined reference to `typeinfo for subprocess::preexec_func::HolderBase'
```
are reported