### PR TITLE
Replace throw with noexcept for C17 compatibility

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -217,7 +217,7 @@ namespace util
    *         Second element is the write descriptor of pipe.
    */
   static inline
-  std::pair<int, int> pipe_cloexec() throw (OSError)
+  std::pair<int, int> pipe_cloexec() noexcept(false)
   {
     int pipe_fds[2];
     int res = pipe(pipe_fds);
@@ -965,15 +965,15 @@ public:
     if (!defer_process_start_) execute_process();
   }
 
-  void start_process() throw (CalledProcessError, OSError);
+  void start_process() noexcept(false);
 
   int pid() const noexcept { return child_pid_; }
 
   int retcode() const noexcept { return retcode_; }
 
-  int wait() throw(OSError);
+  int wait() noexcept(false);
 
-  int poll() throw(OSError);
+  int poll() noexcept(false);
 
   // Does not fail, Caller is expected to recheck the
   // status with a call to poll()
@@ -1017,7 +1017,7 @@ private:
   void init_args(F&& farg, Args&&... args);
   void init_args();
   void populate_c_argv();
-  void execute_process() throw (CalledProcessError, OSError);
+  void execute_process() noexcept(false);
 
 private:
   detail::Streams stream_;
@@ -1066,7 +1066,7 @@ inline void Popen::populate_c_argv()
   cargv_.push_back(nullptr);
 }
 
-inline void Popen::start_process() throw (CalledProcessError, OSError)
+inline void Popen::start_process() noexcept(false)
 {
   // The process was started/tried to be started
   // in the constructor itself.
@@ -1080,7 +1080,7 @@ inline void Popen::start_process() throw (CalledProcessError, OSError)
   execute_process();
 }
 
-inline int Popen::wait() throw (OSError)
+inline int Popen::wait() noexcept(false)
 {
   int ret, status;
   std::tie(ret, status) = util::wait_for_child_exit(pid());
@@ -1095,7 +1095,7 @@ inline int Popen::wait() throw (OSError)
   return 0;
 }
 
-inline int Popen::poll() throw (OSError)
+inline int Popen::poll() noexcept(false)
 {
   int status;
   if (!child_created_) return -1; // TODO: ??
@@ -1137,7 +1137,7 @@ inline void Popen::kill(int sig_num)
 }
 
 
-inline void Popen::execute_process() throw (CalledProcessError, OSError)
+inline void Popen::execute_process() noexcept(false)
 {
   int err_rd_pipe, err_wr_pipe;
   std::tie(err_rd_pipe, err_wr_pipe) = util::pipe_cloexec();


### PR DESCRIPTION
C++11 started to deprecate the use of throw function identifiers.  In C++17, this header no longer compiles due to the deprecation.  Further, cleaned up other gcc compiler warnings around the use of throw.

### Errors due to `throw`

```bash
# g++ -g -Wall -std=c++17 -lpthread -o test_cat test_cat.cc
../subprocess.hpp:220:38: error: ISO C++1z does not allow dynamic exception specifications
   std::pair<int, int> pipe_cloexec() throw (OSError)
                                      ^~~~~
../subprocess.hpp:968:24: error: ISO C++1z does not allow dynamic exception specifications
   void start_process() throw (CalledProcessError, OSError);
                        ^~~~~
../subprocess.hpp:974:14: error: ISO C++1z does not allow dynamic exception specifications
   int wait() throw(OSError);
              ^~~~~
../subprocess.hpp:976:14: error: ISO C++1z does not allow dynamic exception specifications
   int poll() throw(OSError);
              ^~~~~
../subprocess.hpp:1020:26: error: ISO C++1z does not allow dynamic exception specifications
   void execute_process() throw (CalledProcessError, OSError);
                          ^~~~~
../subprocess.hpp:1069:36: error: ISO C++1z does not allow dynamic exception specifications
 inline void Popen::start_process() throw (CalledProcessError, OSError)
                                    ^~~~~
../subprocess.hpp:1083:26: error: ISO C++1z does not allow dynamic exception specifications
 inline int Popen::wait() throw (OSError)
                          ^~~~~
../subprocess.hpp:1098:26: error: ISO C++1z does not allow dynamic exception specifications
 inline int Popen::poll() throw (OSError)
                          ^~~~~
../subprocess.hpp:1140:38: error: ISO C++1z does not allow dynamic exception specifications
 inline void Popen::execute_process() throw (CalledProcessError, OSError)
```

### Other gcc errors discovered after fixing the `throw` identifiers

```bash
../subprocess.hpp: In function 'std::pair<int, int> subprocess::util::pipe_cloexec()':
../subprocess.hpp:225:42: warning: throw will always call terminate() [-Wterminate]
       throw OSError("pipe failure", errno);
                                          ^
../subprocess.hpp: In member function 'int subprocess::Popen::wait()':
../subprocess.hpp:1088:63: warning: throw will always call terminate() [-Wterminate]
     if (errno != ECHILD) throw OSError("waitpid failed", errno);
                                                               ^
../subprocess.hpp: In member function 'int subprocess::Popen::poll()':
../subprocess.hpp:1125:47: warning: throw will always call terminate() [-Wterminate]
     else throw OSError("waitpid failed", errno);
                                               ^
../subprocess.hpp: In member function 'void subprocess::Popen::execute_process()':
../subprocess.hpp:1164:39: warning: throw will always call terminate() [-Wterminate]
     throw OSError("fork failed", errno);
                                       ^
../subprocess.hpp:1206:13: warning: throw will always call terminate() [-Wterminate]
       throw exp;
             ^~~
```

### Testing

```bash
_test_binaries=(
  test
  test_cat
  test_env
  test_err_redirection
  test_ret_code
  test_split
  test_subprocess
)

pushd "test" || exit 1
  for f in ${_test_binaries[@]}; do
    build_line "building test/$f"
    g++ -g -Wall -std=c++17 -lpthread -o "${f}" "${f}.cc"
  done
popd || exit 1

pushd "test" || exit 1
  for f in ${_test_binaries[@]}; do
    build_line "executing test/$f"
    ./"${f}"
  done
popd || exit 1
```

### Environment

```bash
# g++ --version
g++.real (GCC) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

# uname -a
Linux 512a1da44a6c 4.9.93-linuxkit-aufs #1 SMP Wed Jun 6 16:55:56 UTC 2018 x86_64 GNU/Linux
```

Signed-off-by: Ben Dang <me@bdang.it>