### PR TITLE
Add virtual destructor to HolderBase

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -618,6 +618,7 @@ public:
 private:
   struct HolderBase {
     virtual void operator()() const = 0;
+    virtual ~HolderBase(){};
   };
   template <typename T>
   struct FuncHolder: HolderBase {


### PR DESCRIPTION
Adds an empty virtual destructor to HolderBase. Avoids undefined behavior.

"Deleting a derived class object using a pointer to a base class that has a non-virtual destructor results in undefined behavior."