### PR TITLE
Enable basic windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ This library had these design goals:
 
 
 ## Supported Platforms
-Unlike python2.7 subprocess module, this library currently only supports MAC OS and Linux.
-It has no support for Windows in its current state.
+This library supports MAC OS and Linux.
+
+Support for Windows is limited at this time. Please report any specific use-cases that fail,
+and they will be fixed as they are reported.
 
 ## Integration
 Subprocess library has just a single source `subprocess.hpp` present at the top directory of this repository. All you need to do is add
@@ -34,6 +36,7 @@ Checkout http://templated-thoughts.blogspot.in/2016/03/sub-processing-with-moder
 ## Compiler Support
 Linux - g++ 4.8 and above
 Mac OS - Clang 3.4 and later 
+Windows - MSVC 2015 and above
 
 ## Examples
 Here are few examples to show how to get started:

--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1932,6 +1932,12 @@ OutBuffer check_output(const std::string& arg, Args&&... args)
   return (detail::check_output_impl(arg, std::forward<Args>(args)...));
 }
 
+template <typename... Args>
+OutBuffer check_output(std::vector<std::string> plist, Args &&... args)
+{
+  return (detail::check_output_impl(plist, std::forward<Args>(args)...));
+}
+
 
 /*!
  * An easy way to pipeline easy commands.

--- a/test/test_ret_code.cc
+++ b/test/test_ret_code.cc
@@ -8,7 +8,9 @@ void test_ret_code()
   std::cout << "Test::test_poll_ret_code" << std::endl;
   auto p = sp::Popen({"/usr/bin/false"});
   while (p.poll() == -1) {
+#ifndef _MSC_VER
     usleep(1000 * 100);
+#endif
   }
   assert (p.retcode() == 1);
 }

--- a/test/test_subprocess.cc
+++ b/test/test_subprocess.cc
@@ -5,7 +5,11 @@ using namespace subprocess;
 
 void test_exename()
 {
+#ifdef _MSC_VER
+  auto ret = call({"--version"}, executable{"cmake"}, shell{false});
+#else
   auto ret = call({"-l"}, executable{"ls"}, shell{false});
+#endif
   std::cout << ret << std::endl;
 }
 
@@ -35,7 +39,11 @@ void test_easy_piping()
 
 void test_shell()
 {
-  auto obuf = check_output({"ls", "-l"}, shell{false});
+#ifdef _MSC_VER
+  auto obuf = check_output({"cmake", "--version"}, shell{false});
+#else
+  auto obuf = check_output({"ls", "-l"}, shell{false});  
+#endif
   std::cout << obuf.buf.data() << std::endl;
 }
 
@@ -43,9 +51,13 @@ void test_sleep()
 {
   auto p = Popen({"sleep", "30"}, shell{true});
 
-  while (p.poll() == -1) {
+  while (p.poll() == -1)
+  {
     std::cout << "Waiting..." << std::endl;
+#ifdef _MSC_VER
+#else
     sleep(1);
+#endif
   }
 
   std::cout << "Sleep ended: ret code = " << p.retcode() << std::endl;
@@ -53,15 +65,15 @@ void test_sleep()
 
 void test_read_all()
 {
-  Popen p = Popen({"echo","12345678"}, output{PIPE});
-  
+  Popen p = Popen({"echo", "12345678"}, output{PIPE});
+
   std::vector<char> buf(6);
   int rbytes = util::read_all(p.output(), buf);
 
   std::string out(buf.begin(), buf.end());
 
   assert(out == "12345678\n" && rbytes == 9); // echo puts a new line at the end of output
-  std::cout<<"read_all() succeeded"<<std::endl;
+  std::cout << "read_all() succeeded" << std::endl;
 }
 
 void test_simple_cmd()


### PR DESCRIPTION
This pull request:

- Enables basic windows support. 
- Updates the readme to indicate that basic windows support is available.
- Allows the ability to pass vector arguments into certain functions.