### PR TITLE
Add option to disable building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.1)
 project(subprocess CXX)
 
 set(CMAKE_CXX_STANDARD 11)
-enable_testing()
-add_subdirectory(test)
+
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
 install(FILES subprocess.hpp DESTINATION include/subprocess/)


### PR DESCRIPTION
To be able to `make install` the header-only library without having to build anything.

`CTest`, besides conditionally invoking `enable_testing()` and more, adds the option `BUILD_TESTING` which can be turned off when invoking cmake with `-DBUILD_TESTING=OFF`. See also https://cmake.org/cmake/help/latest/module/CTest.html.