### PR TITLE
Remove trailing semicolons on namespace decls

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -521,7 +521,7 @@ namespace util
   }
 #endif
 
-}; // end namespace util
+} // end namespace util
 
 
 
@@ -1068,7 +1068,7 @@ private:
   Communication comm_;
 };
 
-}; // end namespace detail
+} // end namespace detail
 
 
 
@@ -1845,7 +1845,7 @@ namespace detail {
     return std::make_pair(std::move(obuf), std::move(ebuf));
   }
 
-}; // end namespace detail
+} // end namespace detail
 
 
 
@@ -1954,6 +1954,6 @@ OutBuffer pipeline(Args&&... args)
   return (pcmds.back().communicate().first);
 }
 
-};
+}
 
 #endif // SUBPROCESS_HPP


### PR DESCRIPTION
Required to build with `-pedantic` compiler flag under g++ 7.4.0:

Given `test-pedantic.cpp`:

```c++
#include "subprocess.hpp"  // make sure it's in the compilation unit                                                                        
                                                                                                                                            
int main() {                                                                                                                                
    return 0;                                                                                                                               
}
```

Before:

```bash
adam@laptop:~/cpp-subprocess$ g++ -Werror -Wall -pedantic test-pedantic.cpp
In file included from test-pedantic.cpp:1:0:
subprocess.hpp:524:2: error: extra ‘;’ [-Werror=pedantic]
 }; // end namespace util
  ^
subprocess.hpp:1071:2: error: extra ‘;’ [-Werror=pedantic]
 }; // end namespace detail
  ^
subprocess.hpp:1848:2: error: extra ‘;’ [-Werror=pedantic]
 }; // end namespace detail
  ^
subprocess.hpp:1957:2: error: extra ‘;’ [-Werror=pedantic]
 };
```

After:

```bash
adam@laptop:~/cpp-subprocess$ g++ -Werror -Wall -pedantic test-pedantic.cpp 
adam@laptop:~/cpp-subprocess$
```
