### PR TITLE
Forked subprocess not exited if execve failed

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1672,7 +1672,7 @@ namespace detail {
 
     // Calling application would not get this
     // exit failure
-    exit (EXIT_FAILURE);
+    _exit (EXIT_FAILURE);
 #endif
   }
 

--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -670,7 +670,7 @@ struct input
   }
   input(IOTYPE typ) {
     assert (typ == PIPE && "STDOUT/STDERR not allowed");
-#ifndef _MSC_VER    
+#ifndef _MSC_VER
     std::tie(rd_ch_, wr_ch_) = util::pipe_cloexec();
 #endif
   }
@@ -1668,7 +1668,6 @@ namespace detail {
       std::string err_msg(exp.what());
       //ATTN: Can we do something on error here ?
       util::write_n(err_wr_pipe_, err_msg.c_str(), err_msg.length());
-      throw;
     }
 
     // Calling application would not get this


### PR DESCRIPTION
In lengthy processes (daemons, etc) this bug keeps open this subprocess. The subprocess continues to work (parallel to parent process) from after failed command start.
For example, consider this simple test application:

```
#include <iostream>
#include <thread>
#include "subprocess.hpp"


using namespace std;
using namespace subprocess;

int main()
{
    std::vector<char> charVec;
    int retcode = 0;

    cout << "Hello World!" << endl;
    try {
        auto popen = Popen({"/bin/nonexistentcommand"}, output{PIPE}, error{PIPE}, shell{false});
        charVec = popen.communicate().first.buf;
        retcode = popen.retcode();
    } catch (const exception &) {
    }

    if (!charVec.empty()) {
        cout << charVec.data() << endl;
    }
    cout << "retcode " << retcode << endl;
    while (true)
        this_thread::sleep_for(0.5s);

    return 0;
}

```

if it tries to run nonexistentcommand, and stay in loop. When nonexistentcommand failed it will keep open second process. When main process killed, then second process still will be running.