### PR TITLE
Fix for poll() function on windows

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1299,7 +1299,10 @@ inline int Popen::wait() noexcept(false)
 inline int Popen::poll() noexcept(false)
 {
   int status;
+
+#ifndef _MSC_VER
   if (!child_created_) return -1; // TODO: ??
+#endif
 
 #ifdef _MSC_VER
   int ret = WaitForSingleObject(process_handle_, 0);


### PR DESCRIPTION
When compiling on windows the poll() function checks child_created_ value which exists but it's never set to to true, the only code paths that ever set it to true are not compiled on windows so this effectively makes the function always return -1. After this change processes on windows return the proper exit code.