### PR TITLE
Namespace library with github name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,4 @@ if(BUILD_TESTING)
     add_subdirectory(test)
 endif()
 
-install(FILES subprocess.hpp DESTINATION include/subprocess/)
+install(FILES subprocess.hpp DESTINATION include/cpp-subprocess/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and they will be fixed as they are reported.
 Subprocess library has just a single source `subprocess.hpp` present at the top directory of this repository. All you need to do is add
 
 ```cpp
-#inlcude "subprocess.hpp"
+#inlcude "cpp-subprocess/subprocess.hpp"
 
 using namespace subprocess;
 // OR


### PR DESCRIPTION
While this is header-only, and users are expected
to download the header and commit it to their project, it's better to
have unique namespace for the header by default.

This has two reasons:

  1. I wish to enable installing it with conan.io, and want to reduce
     the possibility for namespace clashes. The term "subprocess" is
     pretty overloaded.
  2. Currently the README and the CMakeLists differ in their include
     path, it's better to be consistent, even though users can put it
     wherever they please in their project.

Since most users are using it as header only anyway, I don't think it'd
make much diference.