### PR TITLE
Expose headers in cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,7 @@ if(BUILD_TESTING)
     add_subdirectory(test)
 endif()
 
+add_library(subprocess INTERFACE)
+target_include_directories(subprocess INTERFACE .)
+
 install(FILES subprocess.hpp DESTINATION include/cpp-subprocess/)


### PR DESCRIPTION
Expose through CMake directives, the name of the project so that package managers such as
CPM (https://github.com/cpm-cmake/CPM.cmake) could consume this library cleanly

closes #78 