### PR TITLE
link tests targets with thread library

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,11 @@
 set(test_names test_subprocess test_cat test_env test_err_redirection test_split test_main test_ret_code)
 set(test_files env_script.sh write_err.sh write_err.txt)
 
+find_package(Threads REQUIRED)
+
 foreach(test_name IN LISTS test_names)
     add_executable(${test_name} ${test_name}.cc)
+    target_link_libraries(${test_name} PRIVATE Threads::Threads)
 
     add_test(
         NAME ${test_name}


### PR DESCRIPTION
when building the test targets, I got undefined refs of thread library like pthread_create.