### PR TITLE
Add retcode to CalledProcessError

### DIFF
--- a/test/test_ret_code.cc
+++ b/test/test_ret_code.cc
@@ -27,9 +27,25 @@ void test_ret_code_comm()
   std::cout << "retcode: " << cut.retcode() << std::endl;
 }
 
+void test_ret_code_check_output()
+{
+  using namespace sp;
+  bool caught = false;
+  try {
+      auto obuf = check_output({"/bin/false"}, shell{false});
+      assert(false); // Expected to throw
+  } catch (CalledProcessError &e) {
+      std::cout << "retcode: " << e.retcode << std::endl;
+      assert (e.retcode == 1);
+      caught = true;
+  }
+  assert(caught);
+}
+
 int main() {
   // test_ret_code();
   test_ret_code_comm();
+  test_ret_code_check_output();
 
   return 0;
 }


### PR DESCRIPTION
It's useful to be able to know the exit code of the process when it
fails with a non-zero exit code.

To get this to work, I had to fix a bug in the implementation of
check_output. Previously, check_output would call both `p.communicate()`
and `p.poll()`. The former has the effect of waiting for EOF on the
input and then waiting for the child to exit, reaping it with
`waitpid(2)`. Unfortunately, `p.poll()` was hoping to be able to also
use `waitpid(2)` to retrieve the exit code of the process. But since the
child had already been reaped, the given pid no longer existed, and thus
`waitpid(2)` would return `ECHILD`.

Luckily the call to `p.poll()` is unnecessary, as the process already
provides `p.retcode()` for retrieving the exit code.