### PR TITLE
Create Popen::communicate overload for std::string

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1298,6 +1298,11 @@ public:
     return res;
   }
 
+  std::pair<OutBuffer, ErrBuffer> communicate(const std::string& msg)
+  {
+    return communicate(msg.c_str(), msg.size());
+  }
+
   std::pair<OutBuffer, ErrBuffer> communicate(const std::vector<char>& msg)
   {
     auto res = stream_.communicate(msg);

--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1288,6 +1288,9 @@ public:
   int send(const char* msg, size_t length)
   { return stream_.send(msg, length); }
 
+  int send(const std::string& msg)
+  { return send(msg.c_str(), msg.size()); }
+
   int send(const std::vector<char>& msg)
   { return stream_.send(msg); }
 


### PR DESCRIPTION
Hello. There are `Popen::communicate` overloads for raw characters arrays and vectors but not for strings. I think it would be convenient to have such overload. Same for `Popen::send`.