### PR TITLE
fix overload thread

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -627,7 +627,7 @@ namespace util
     int status = 0;
     int ret = -1;
     while (1) {
-      ret = waitpid(pid, &status, WNOHANG);
+      ret = waitpid(pid, &status, 0);
       if (ret == -1) break;
       if (ret == 0) continue;
       return std::make_pair(ret, status);


### PR DESCRIPTION
The purpose of the method is to wait for the process to complete. Because of the parameter WNOHANG, the process returned with a result of 0 and repeats the loop again. Thus, the wait method loads the thread by 100%.