### PR TITLE
Install guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,17 @@ project(subprocess VERSION 0.0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to use")
 option(EXPORT_COMPILE_COMMANDS "create clang compile database" ON)
 option(SUBPROCESS_TESTS "enable subprocess tests" OFF)
+option(SUBPROCESS_INSTALL "enable subprocess install" OFF)
 
 find_package(Threads REQUIRED)
 
 add_library(subprocess INTERFACE)
 target_link_libraries(subprocess INTERFACE Threads::Threads)
 target_include_directories(subprocess INTERFACE . )
-install(FILES subprocess.hpp DESTINATION include/cpp-subprocess/)
+
+if(SUBPROCESS_INSTALL)
+    install(FILES subprocess.hpp DESTINATION include/cpp-subprocess/)
+endif()
 
 if(SUBPROCESS_TESTS)
     include(CTest)


### PR DESCRIPTION
When using this as a submodule and attempting to install the parent project, this will be installed as well which is undesirable. Having this guard makes it explicit that you also want this to be installed with the parent.