### PR TITLE
ci: Switch CMake build configuration from Release to Debug

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -17,14 +17,14 @@ jobs:
       fail-fast: false
 
       # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 1. <Windows, Debug, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Debug, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Debug, latest Clang compiler toolchain on the default runner image, default generator>
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build_type: [Release]
+        build_type: [Debug]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest


### PR DESCRIPTION
By default, CMake defines `NDEBUG` for the Release build configuration, which effectively disables assertions and makes CI jobs less useful.