### PR TITLE
Fix exception when `CreateProcessW` fails and add test for it

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_names test_subprocess test_cat test_env test_err_redirection test_split test_main test_ret_code)
+set(test_names test_subprocess test_cat test_env test_err_redirection test_exception test_split test_main test_ret_code)
 set(test_files env_script.sh write_err.sh write_err.txt)
 
 

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <cstring>
+#include <subprocess.hpp>
+
+namespace sp = subprocess;
+
+void test_exception()
+{
+  bool caught = false;
+  try {
+    auto p = sp::Popen("invalid_command");
+    assert(false); // Expected to throw
+  } catch (sp::CalledProcessError& e) {
+#ifdef __USING_WINDOWS__
+    assert(std::strstr(e.what(), "CreateProcess failed: The system cannot find the file specified."));
+#else
+    assert(std::strstr(e.what(), "execve failed: No such file or directory"));
+#endif
+    caught = true;
+  }
+  assert(caught);
+}
+
+int main() {
+  test_exception();
+  return 0;
+}


### PR DESCRIPTION
This PR makes the behavior consistent across all supported systems.

Also a new `test_exception` has been introduced to avoid any related regressions in the future.

The error strings are the same as used in the Boost.Process, which makes [migration](https://github.com/bitcoin/bitcoin/pull/28981) from it a bit easier :)