### PR TITLE
Fix cross-compiling with mingw toolchain

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -61,7 +61,7 @@ Documentation for C++ subprocessing libraray.
 
 extern "C" {
 #ifdef __USING_WINDOWS__
-  #include <Windows.h>
+  #include <windows.h>
   #include <io.h>
   #include <cwchar>
 
@@ -155,7 +155,7 @@ public:
 //--------------------------------------------------------------------
 
 //Environment Variable types
-#ifndef _MSC_VER
+#ifndef __USING_WINDOWS__
 	using env_string_t = std::string;
 	using env_char_t = char;
 #else


### PR DESCRIPTION
This PR makes possible to cross-compile for Windows using the MinGW-w64 toolchain as follows:
```
cmake -B build -DSUBPROCESS_TESTS=ON -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++-posix
cmake --build build
```

This PR supersedes https://github.com/arun11299/cpp-subprocess/pull/63.