### PR TITLE
Explicitly define move constructor of Streams class.

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1057,7 +1057,10 @@ class Communication
 public:
   Communication(Streams* stream): stream_(stream)
   {}
-  void operator=(const Communication&) = delete;
+  Communication(const Communication&) = delete;
+  Communication& operator=(const Communication&) = delete;
+  Communication(Communication&&) = default;
+  Communication& operator=(Communication&&) = default;
 public:
   int send(const char* msg, size_t length);
   int send(const std::vector<char>& msg);
@@ -1094,7 +1097,10 @@ class Streams
 {
 public:
   Streams():comm_(this) {}
-  void operator=(const Streams&) = delete;
+  Streams(const Streams&) = delete;
+  Streams& operator=(const Streams&) = delete;
+  Streams(Streams&&) = default;
+  Streams& operator=(Streams&&) = default;
 
 public:
   void setup_comm_channels();


### PR DESCRIPTION
This suppresses the following warning caused by clang-20.

```
error: definition of implicit copy constructor for 'Streams' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
```

Copy constructor or move constructor is called when std::vector re-allocates memory. In this case, move constructor should be called, because copying Streams instances breaks file-descriptor management.

Communication class is modified as well, since it's instance is a member of Streams class.