### PR TITLE
Get Windows return code in wait()

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -1408,7 +1408,12 @@ inline int Popen::wait() noexcept(false)
 #ifdef __USING_WINDOWS__
   int ret = WaitForSingleObject(process_handle_, INFINITE);
 
-  return 0;
+  DWORD dretcode_;
+
+  if (FALSE == GetExitCodeProcess(process_handle_, &dretcode_))
+      throw OSError("Failed during call to GetExitCodeProcess", 0);
+
+  return (int)dretcode_;
 #else
   int ret, status;
   std::tie(ret, status) = util::wait_for_child_exit(pid());


### PR DESCRIPTION
Currently, wait() returns 0 on windows regardless of the actual return code of processes.