### PR TITLE
Fix string_arg when used with rref

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -706,7 +706,7 @@ struct string_arg
 {
   string_arg(const char* arg): arg_value(arg) {}
   string_arg(std::string&& arg): arg_value(std::move(arg)) {}
-  string_arg(std::string arg): arg_value(std::move(arg)) {}
+  string_arg(const std::string& arg): arg_value(arg) {}
   std::string arg_value;
 };
 


### PR DESCRIPTION
When passing in a rvalue reference, compiler considers it ambiguous between std::string and std::string&&. Making one of them take a lvalue reference makes compilers correctly pick the right one depending on whether the passed in value binds to a rvalue or lvalue reference.