### PR TITLE
Do not escape double quotes for command line arguments on Windows

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -193,7 +193,7 @@ namespace util
     //
 
     if (force == false && argument.empty() == false &&
-        argument.find_first_of(L" \t\n\v\"") == argument.npos) {
+        argument.find_first_of(L" \t\n\v") == argument.npos) {
       command_line.append(argument);
     }
     else {

--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -182,12 +182,6 @@ using env_vector_t = std::vector<platform_char_t>;
 //--------------------------------------------------------------------
 namespace util
 {
-  template <typename R>
-  inline bool is_ready(std::shared_future<R> const &f)
-  {
-    return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
-  }
-
   inline void quote_argument(const std::wstring &argument, std::wstring &command_line,
                       bool force)
   {

--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -182,6 +182,7 @@ using env_vector_t = std::vector<platform_char_t>;
 //--------------------------------------------------------------------
 namespace util
 {
+#ifdef __USING_WINDOWS__
   inline void quote_argument(const std::wstring &argument, std::wstring &command_line,
                       bool force)
   {
@@ -242,7 +243,6 @@ namespace util
     }
   }
 
-#ifdef __USING_WINDOWS__
   inline std::string get_last_error(DWORD errorMessageID)
   {
     if (errorMessageID == 0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_names test_subprocess test_cat test_env test_err_redirection test_exception test_split test_main test_ret_code)
+set(test_names test_subprocess test_cat test_double_quotes test_env test_err_redirection test_exception test_split test_main test_ret_code)
 set(test_files env_script.sh write_err.sh write_err.txt)
 
 

--- a/test/test_double_quotes.cc
+++ b/test/test_double_quotes.cc
@@ -1,0 +1,30 @@
+#include <subprocess.hpp>
+
+#include <cassert>
+#include <string>
+
+namespace sp = subprocess;
+
+// JSON requires the use of double quotes (see: https://json.org/).
+// This test verifies proper handling of them.
+void test_double_quotes()
+{
+    // A simple JSON object.
+    const std::string expected{"{\"name\": \"value\"}"};
+#ifdef __USING_WINDOWS__
+    const std::string command{"cmd.exe /c echo "};
+#else
+    const std::string command{"echo "};
+#endif
+    auto p = sp::Popen(command + expected, sp::output{sp::PIPE});
+    const auto out = p.communicate().first;
+    std::string result{out.buf.begin(), out.buf.end()};
+    // The `echo` command appends a newline.
+    result.erase(result.find_last_not_of(" \n\r\t") + 1);
+    assert(result == expected);
+}
+
+int main() {
+  test_double_quotes();
+  return 0;
+}


### PR DESCRIPTION
This PR fixes the handling of double quotes and aligns the behavior with Python's `Popen` class. For example:
```python
import subprocess
p = subprocess.Popen("cmd.exe /c dir \"C:\\Program Files\"", stdout=subprocess.PIPE, text=True)
print(f"Captured stdout:\n{stdout}")
```

Currently, the same command line processed by the `util::quote_argument()` function looks like:
```
cmd.exe /c dir "\"C:\Program" "Files\""
```
which is broken.

With PR change, it looks correct:
```
cmd.exe /c dir "C:\Program Files"
```

Additionally, this PR:
- Removes the unused code.
- Refactors code to make subsequent changes easier to review.
- Adds a test to prevent future regressions.