### PR TITLE
Fix missing error check in set_clo_on_exec for FD_CLOEXEC handling

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -471,10 +471,14 @@ namespace util
   void set_clo_on_exec(int fd, bool set = true)
   {
     int flags = fcntl(fd, F_GETFD, 0);
+    if (flags == -1) {
+        throw OSError("fcntl F_GETFD failed", errno);
+    }
     if (set) flags |= FD_CLOEXEC;
     else flags &= ~FD_CLOEXEC;
-    //TODO: should check for errors
-    fcntl(fd, F_SETFD, flags);
+    if (fcntl(fd, F_SETFD, flags) == -1) {
+        throw OSError("fcntl F_SETFD failed", errno);
+    }
   }
 
 


### PR DESCRIPTION
####  Changes:
- Replaces unchecked `fcntl(fd, F_SETFD, flags);` with a version that checks the return value.
- Throws `OSError` on failure with an appropriate error message.

####  Motivation:
Proper error handling is critical in system-level code to avoid silent failures, especially when setting file descriptor flags like `FD_CLOEXEC`. This fix ensures robustness and helps catch configuration issues early during process setup.

### Test coverage
No functional change beyond improved error propagation, but this section of code is indirectly exercised by any subprocess-related integration or functional tests. Consider adding a unit test for `set_clo_on_exec` in the future for completeness.
