### PR TITLE
windows: Don't add an extra whitespace at end of Windows command line

### DIFF
--- a/cpp-subprocess/subprocess.hpp
+++ b/cpp-subprocess/subprocess.hpp
@@ -1541,11 +1541,16 @@ inline void Popen::execute_process() noexcept(false)
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring argument;
   std::wstring command_line;
+  bool first_arg = true;
 
   for (auto arg : this->vargs_) {
+    if (!first_arg) {
+      command_line += L" ";
+    } else {
+      first_arg = false;
+    }
     argument = converter.from_bytes(arg);
     util::quote_argument(argument, command_line, false);
-    command_line += L" ";
   }
 
   // CreateProcessW can modify szCmdLine so we allocate needed memory


### PR DESCRIPTION
The windows code adds an unnecessary extra space to the command line. This can cause subtle issues, so avoid it.