### PR TITLE
refactor: add [[noreturn]] attribute to execute_child

### DIFF
--- a/cpp-subprocess/subprocess.hpp
+++ b/cpp-subprocess/subprocess.hpp
@@ -1183,7 +1183,7 @@ public:
     err_wr_pipe_(err_wr_pipe)
   {}
 
-  void execute_child();
+  [[noreturn]] void execute_child();
 
 private:
   // Lets call it parent even though


### PR DESCRIPTION
This came up downstream, when compiling with `-Wmissing-noreturn`.